### PR TITLE
molecules/message のmarginを修正

### DIFF
--- a/src/components/molecules/message/message.scss
+++ b/src/components/molecules/message/message.scss
@@ -12,7 +12,7 @@
   }
 
   .title-text {
-    margin-bottom: 6px;
+    margin-bottom: 8px;
     font-family: $fontfamily-mincho;
     font-size: $fontsize-l;
     line-height: 1.5;


### PR DESCRIPTION
organisms-topsを作成中、marginの値がfigmaと違ったので修正しました。

（作成済みのコンポーネントを修正する際のPRの例です。）
（ブランチ名が `fix-message-margin` となっていますが、`fix/<変更内容>` という命名で作成するようにしてください。）